### PR TITLE
fix link to GeoIP dat files from kubernetes/ingress-nginx repo

### DIFF
--- a/0/debian-9/Dockerfile
+++ b/0/debian-9/Dockerfile
@@ -9,12 +9,12 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
     rm -rf /tmp/bitnami/pkg/cache/nginx-ingress-controller-0.24.1-0-linux-amd64-debian-9.tar.gz
 RUN mkdir -p /opt/bitnami/nginx/conf/geoip && \
     cd /opt/bitnami/nginx/conf/geoip && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xvz && mv GeoLite2-City_*/*mmdb . && rm -r GeoLite2-City_*/ && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz | tar xvz && mv GeoLite2-Country_*/*mmdb . && rm -r GeoLite2-Country_*/ && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz | tar xvz && mv GeoLite2-ASN_*/*mmdb . && rm -r GeoLite2-ASN_*/ &&\
-    curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoIP.dat --output GeoIP.dat &&\
-     curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoIPASNum.dat --output GeoIPASNum.dat &&\
-    curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoLiteCity.dat --output GeoLiteCity.dat
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xvz && mv GeoLite2-City_*/*mmdb . && rm -r GeoLite2-City_*/ && \
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz | tar xvz && mv GeoLite2-Country_*/*mmdb . && rm -r GeoLite2-Country_*/ && \
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz | tar xvz && mv GeoLite2-ASN_*/*mmdb . && rm -r GeoLite2-ASN_*/ &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoIP.dat --output GeoIP.dat &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoIPASNum.dat --output GeoIPASNum.dat &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoLiteCity.dat --output GeoLiteCity.dat
 
 COPY rootfs /
 RUN ln -sf /opt/bitnami/nginx/sbin/nginx /usr/sbin/nginx

--- a/0/rhel-7/Dockerfile
+++ b/0/rhel-7/Dockerfile
@@ -9,12 +9,12 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
     rm -rf /tmp/bitnami/pkg/cache/nginx-ingress-controller-0.24.1-0-linux-x86_64-rhel-7.tar.gz
 RUN mkdir -p /opt/bitnami/nginx/conf/geoip && \
     cd /opt/bitnami/nginx/conf/geoip && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xvz && mv GeoLite2-City_*/*mmdb . && rm -r GeoLite2-City_*/ && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz | tar xvz && mv GeoLite2-Country_*/*mmdb . && rm -r GeoLite2-Country_*/ && \
-    curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz | tar xvz && mv GeoLite2-ASN_*/*mmdb . && rm -r GeoLite2-ASN_*/ &&\
-    curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoIP.dat --output GeoIP.dat &&\
-     curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoIPASNum.dat --output GeoIPASNum.dat &&\
-    curl -L https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/geoip/GeoLiteCity.dat --output GeoLiteCity.dat
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xvz && mv GeoLite2-City_*/*mmdb . && rm -r GeoLite2-City_*/ && \
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz | tar xvz && mv GeoLite2-Country_*/*mmdb . && rm -r GeoLite2-Country_*/ && \
+    curl -fL https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz | tar xvz && mv GeoLite2-ASN_*/*mmdb . && rm -r GeoLite2-ASN_*/ &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoIP.dat --output GeoIP.dat &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoIPASNum.dat --output GeoIPASNum.dat &&\
+    curl -fL https://github.com/kubernetes/ingress-nginx/raw/master/images/nginx/rootfs/etc/nginx/geoip/GeoLiteCity.dat --output GeoLiteCity.dat
 
 COPY rootfs /
 RUN rpm -Uvh https://s3.amazonaws.com/aaronsilber/public/authbind-2.1.1-0.1.x86_64.rpm


### PR DESCRIPTION
The GeoIP resources (duplicates) were removed in https://github.com/kubernetes/ingress-nginx/commit/6d0f3a00c734642be1be795d355e8d023120b222.
This PR updates download URLs to point to files located at https://github.com/kubernetes/ingress-nginx/tree/master/images/nginx/rootfs/etc/nginx/geoip.

Additionally the `-f` flag has been added to the `curl` commands so that such errors are caught while building the image.

Fixes #3

request, mention that information here.-->